### PR TITLE
Implement peak finding algorithm using regionprops

### DIFF
--- a/pycrystem/diffraction_signal.py
+++ b/pycrystem/diffraction_signal.py
@@ -549,6 +549,8 @@ class ElectronDiffraction(Signal2D):
             * 'difference_of_gaussians' - a blob finder implemented in
               `scikit-image` which uses the difference of Gaussian matrices
               approach.
+            * 'regionprops' - Uses regionprops to find islands of connected
+               pixels representing a peak
 
         *args
             associated with above methods
@@ -570,6 +572,7 @@ class ElectronDiffraction(Signal2D):
             'stat': find_peaks_stat,
             'laplacian_of_gaussians':  find_peaks_log,
             'difference_of_gaussians': find_peaks_dog,
+            'regionprops': find_peaks_regionprops,
         }
         if method in method_dict:
             method = method_dict[method]

--- a/pycrystem/utils/peakfinder2D_gui.py
+++ b/pycrystem/utils/peakfinder2D_gui.py
@@ -24,7 +24,7 @@ from IPython.display import display
 from .peakfinders2D import *
 
 METHODS = [find_peaks_max, find_peaks_minmax, find_peaks_zaefferer,
-           find_peaks_stat, find_peaks_dog, find_peaks_log]
+           find_peaks_stat, find_peaks_dog, find_peaks_log, find_peaks_regionprops]
 
 
 class PeakFinderUIBase:

--- a/pycrystem/utils/peakfinders2D.py
+++ b/pycrystem/utils/peakfinders2D.py
@@ -16,11 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with PyCrystEM.  If not, see <http://www.gnu.org/licenses/>.
 
-import matplotlib.pyplot as plt
 import numpy as np
 from skimage.feature import peak_local_max
 import scipy.ndimage as ndi
-import scipy as sp
 import copy
 
 NO_PEAKS = np.array([[np.nan, np.nan]])
@@ -399,3 +397,50 @@ def find_peaks_log(z, min_sigma=1., max_sigma=50., num_sigma=10.,
     except IndexError:
         return NO_PEAKS
     return centers
+
+
+def find_peaks_regionprops(z, min_sigma=4, max_sigma=5, threshold=1, 
+                           min_size=50, return_props=False):
+    """
+    Finds peaks using regionprops.
+    Uses the difference of two gaussian convolutions to separate signal from 
+    background, and then uses the skimage.measure.regionprops function to find 
+    connected islands (peaks). Small blobs can be rejected using `min_size`.
+
+    Parameters
+    ----------
+    z : ndarray
+        Array of image intensities.
+    min_sigma : int, float
+        Standard deviation for the minimum gaussian convolution
+    max_sigma : int, float
+        Standard deviation for the maximum gaussian convolution
+    threshold : int, float
+        Minimum difference in intensity
+    min_size : int
+        Minimum size in pixels of blob
+    return_props : bool
+        Return skimage.measure.regionprops
+
+    Returns
+    -------
+    ndarray
+        (n_peaks, 2)
+        Array of peak coordinates.
+
+    """
+    from skimage import morphology, measure
+
+    difference = ndi.gaussian_filter(z, min_sigma) - ndi.gaussian_filter(z, max_sigma)
+            
+    labels, numlabels = ndi.label(difference > threshold)
+    labels = morphology.remove_small_objects(labels, min_size)
+            
+    props = measure.regionprops(labels, z)
+            
+    if return_props:
+        return props
+    else:
+        peaks = np.array([prop.centroid for prop in props])
+        return clean_peaks(peaks)
+


### PR DESCRIPTION
This is a peak finding algorithm that I have found useful for my data. It uses a difference of gaussians, but then uses skimage.measure.regionprops to detect islands of connected pixels. 

This fixes a problem with some of the other peak finders that if a frame is noisy or has little signal, many peaks are returned. Most annoyingly matplotlib doesn't like this and often hangs or crashes as a result. Often these are single pixels standing out. By using this approach, a minimum size for the number of pixels in a blob can be specified in order to filter these out.

BTW great work on the peakfinder2D_gui, I just had to add the function to the list and it picked it up immediately! Very cool!