### PR TITLE
Fixing #65 by keeping two navigation dimensions.

### DIFF
--- a/pycrystem/diffraction_signal.py
+++ b/pycrystem/diffraction_signal.py
@@ -739,6 +739,12 @@ class ElectronDiffraction(Signal2D):
                   calibration=self.axes_manager.signal_axes[0].scale)
         peaks = DiffractionVectors(peaks)
         peaks.axes_manager.set_signal_dimension(0)
+        if peaks.axes_manager.navigation_dimension != self.axes_manager.navigation_dimension:
+            #ToDo Remove this hardcore            
+            peaks = peaks.transpose(navigation_axes=2)
+        if peaks.axes_manager.navigation_dimension != self.axes_manager.navigation_dimension:
+            raise RuntimeWarning('You do not have the same size navigation axes for your \
+            Diffraction pattern and your peaks')
         return peaks
 
     def find_peaks_interactive(self, imshow_kwargs={}):


### PR DESCRIPTION
This solves the 'ragged peaks' problem, but might need revising if using one/three navigation dimensions become prevalent.