### PR TITLE
Make image and pattern have the same mask 

### DIFF
--- a/pycrystem/utils/__init__.py
+++ b/pycrystem/utils/__init__.py
@@ -74,7 +74,7 @@ def correlate(image, pattern,
         image_intensities = ip.ev(pattern.coordinates[:, 0][mask],
                                   pattern.coordinates[:, 1][mask])
     else:
-        image_intensities = image.T[pixel_coordinates[:, 0][in_bounds], pixel_coordinates[:, 1][in_bounds]]
+        image_intensities = image.T[pixel_coordinates[:, 0][mask], pixel_coordinates[:, 1][mask]]
     pattern_intensities = pattern_intensities[mask]
     return np.nan_to_num(_correlate(image_intensities, pattern_intensities))
 


### PR DESCRIPTION
Closing #67 

####

It seems that  

`(in_bounds & large_intensities) == in_bounds`

in the vast majority of cases (hence why the issue was so specific) - but in general we should use the same mask for both.